### PR TITLE
gst-libs/gst/codecparsers/Makefile.am: Remove the duplicated .h file

### DIFF
--- a/gst-libs/gst/codecparsers/Makefile.am
+++ b/gst-libs/gst/codecparsers/Makefile.am
@@ -15,7 +15,6 @@ noinst_HEADERS = parserutils.h nalutils.h dboolhuff.h vp8utils.h
 
 libgstcodecparsers_@GST_API_VERSION@include_HEADERS = \
 	gstmpegvideoparser.h gsth264parser.h gstvc1parser.h gstmpeg4parser.h \
-	gsth265parser.h \
 	gsth265parser.h gstvp8parser.h gstvp8rangedecoder.h \
 	gstjpegparser.h \
 	gstmpegvideometa.h \


### PR DESCRIPTION
To fix the “make install” error

Signed-off-by: Yong Li <yong.b.li@intel.com>